### PR TITLE
refactor: add service layer

### DIFF
--- a/back/src/main/java/com/haust/back/controller/CommentController.java
+++ b/back/src/main/java/com/haust/back/controller/CommentController.java
@@ -1,70 +1,51 @@
 package com.haust.back.controller;
 
-import java.sql.Timestamp;
-import java.util.Date;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
-import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.haust.back.entity.Comment;
-import com.haust.back.mapper.CommentMapper;
-
+import com.haust.back.service.CommentService;
 import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class CommentController {
     @Autowired
-    private CommentMapper commentMapper;
+    private CommentService commentService;
     @ApiOperation("添加一条评论，需传入评论内容")
     @PostMapping("/comment/insert")
     public Comment insertComment(Comment comment)
     {
-        Date date = new Date();//获得当前时间
-        Timestamp t = new Timestamp(date.getTime());//将时间转换成Timestamp类型，这样便可以存入到Mysql数据库中
-        comment.setCDate(t);
-        commentMapper.insert(comment);
-        return comment;
+        return commentService.insertComment(comment);
     }
     @ApiOperation("分页查询指定nid新闻的所有评论，需传入新闻ID，默认每次查询5条数据")
     @GetMapping("/comment/{nid}/{id}/{size}")
-    public IPage getCommentByid(@PathVariable Integer nid,@PathVariable int id,@PathVariable int size)
+    public IPage<Comment> getCommentByid(@PathVariable Integer nid,@PathVariable int id,@PathVariable int size)
     {
-        Page<Comment> page = new Page<>(id, size);
-        IPage iPage = commentMapper.selectPage(page, new QueryWrapper<Comment>().eq("new_id", nid));
-        return iPage;
+        return commentService.getCommentById(nid,id,size);
     }
     @ApiOperation("查询指定nid新闻的点赞数量，需传入新闻ID")
     @GetMapping("/comment/like/{nid}")
     public Integer getlike(@PathVariable Integer nid)
     {
-        Integer like = commentMapper.selectCount(new QueryWrapper<Comment>().eq("new_id", nid));
-        return like;
+        return commentService.getLike(nid);
     }
     @ApiOperation("查询指定nid新闻的点踩数量，需传入新闻ID")
     @GetMapping("/comment/gdislike/{nid}")
     public Integer getdislike(@PathVariable Integer nid)
     {
-        Integer like = commentMapper.selectCount(new QueryWrapper<Comment>().eq("new_id", nid));
-        return like;
+        return commentService.getDislike(nid);
     }
     @ApiOperation("增加指定nid新闻的点赞数量，需传入新闻ID")
     @GetMapping("/comment/plike/{nid}")
     public Integer postlike(@PathVariable Integer nid)
     {
-        Integer like = commentMapper.selectCount(new QueryWrapper<Comment>().eq("new_id", nid));
-        return like;
+        return commentService.postLike(nid);
     }
     @ApiOperation("增加指定nid新闻的点踩数量，需传入新闻ID")
     @GetMapping("/comment/pdislike/{nid}")
     public Integer postdislike(@PathVariable Integer nid)
     {
-        Integer like = commentMapper.selectCount(new QueryWrapper<Comment>().eq("new_id", nid));
-        return like;
+        return commentService.postDislike(nid);
     }
 }
+

--- a/back/src/main/java/com/haust/back/controller/NewController.java
+++ b/back/src/main/java/com/haust/back/controller/NewController.java
@@ -1,10 +1,8 @@
 package com.haust.back.controller;
 
-import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
-import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.haust.back.entity.New;
-import com.haust.back.mapper.NewMapper;
+import com.haust.back.service.NewService;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -12,59 +10,50 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class NewController {
     @Autowired
-    private NewMapper newMapper;
+    private NewService newService;
     @ApiOperation("对所有的新闻进行分页查询，默认每次查询5条数据")
     @GetMapping("/news/findbypage/{id}/{size}")
-    public IPage getNewsPage(@PathVariable int id,@PathVariable int size)
+    public IPage<New> getNewsPage(@PathVariable int id,@PathVariable int size)
     {
-        Page<New> page = new Page<>(id, size);
-        IPage iPage = newMapper.selectPage(page, null);
-        return iPage;
+        return newService.getNewsPage(id,size);
     }
     @ApiOperation("对不同分类的新闻进行分页查询，需传入新闻分类id，默认每次查询5条数据")
     @GetMapping("/news/{cid}/{id}/{size}")
-    public IPage getNewsPageByCid(@PathVariable int cid,@PathVariable int id,@PathVariable int size)
+    public IPage<New> getNewsPageByCid(@PathVariable int cid,@PathVariable int id,@PathVariable int size)
     {
-        Page<New> page = new Page<>(id, size);
-        IPage iPage = newMapper.selectPage(page, new QueryWrapper<New>().eq("new_cid", cid));
-        return iPage;
+        return newService.getNewsPageByCid(cid,id,size);
     }
     @ApiOperation("对不同日期的新闻进行分页查询，需传入新闻日期，默认每次查询5条数据")
     @GetMapping("/news/pagebydate/{date}/{id}/{size}")
-    public IPage getNewsPageByDate(@PathVariable String date,@PathVariable int id,@PathVariable int size)
+    public IPage<New> getNewsPageByDate(@PathVariable String date,@PathVariable int id,@PathVariable int size)
     {
-        Page<New> page = new Page<>(id, size);
-        IPage iPage = newMapper.selectPage(page, new QueryWrapper<New>().eq("new_date", date));
-        return iPage;
+        return newService.getNewsPageByDate(date,id,size);
     }
     @ApiOperation("查询指定新闻的详细内容，需传入新闻id")
     @GetMapping("/newdetail/{id}")
     public New getNewsDetailById(@PathVariable int id)
     {
-        New news = newMapper.selectById(id);
-        return news;
+        return newService.getNewsDetailById(id);
     }
     @ApiOperation("添加一条新闻，需传入新闻的详细内容")
     @PostMapping("/news/insert")
     public New insertNews(New news)
     {
-        //System.out.println(news);
-        int i = newMapper.insert(news);
-        return news;
+        return newService.insertNews(news);
     }
     @ApiOperation("更新一条新闻信息，根据传入的新闻id进行匹配，需传入更新新闻的详细内容")
     @PutMapping("/news/update")
         public New updateNew(New news)
     {
-        int num = newMapper.update(news, new QueryWrapper<New>().eq("new_id", news.getNewId()));
-        return num==1?news:null;
+        return newService.updateNew(news);
     }
 
     @ApiOperation("删除一条新闻信息，需传入新闻id进行匹配")
     @DeleteMapping("/new/{id}")
     public int  deleteNewById(@PathVariable Integer id)
     {
-        return newMapper.deleteById(id);
+        return newService.deleteNewById(id);
     }
 
 }
+

--- a/back/src/main/java/com/haust/back/controller/NewstatusController.java
+++ b/back/src/main/java/com/haust/back/controller/NewstatusController.java
@@ -1,64 +1,51 @@
 package com.haust.back.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.haust.back.entity.Newstatus;
-import com.haust.back.mapper.NewstatusMapper;
-
+import com.haust.back.service.NewstatusService;
 import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class NewstatusController {
     @Autowired
-    private NewstatusMapper newstatusMapper;
+    private NewstatusService newstatusService;
 
     @ApiOperation("查询指定新闻内容的行为数据，需传入新闻ID")
     @GetMapping("/newstatus/status/{nid}")
     public Newstatus getstatusbynid(@PathVariable Integer nid) {
-        return newstatusMapper.selectOne(new QueryWrapper<Newstatus>().eq("new_id", nid));
+        return newstatusService.getStatusByNid(nid);
     }
 
     @ApiOperation("查询指定nid新闻的点赞数量，需传入新闻ID")
     @GetMapping("/newstatus/like/{nid}")
     public Integer getlike(@PathVariable Integer nid) {
-        Integer like = newstatusMapper.selectCount(new QueryWrapper<Newstatus>().eq("new_id", nid));
-        return like;
+        return newstatusService.getLike(nid);
     }
 
     @ApiOperation("查询指定nid新闻的点踩数量，需传入新闻ID")
     @GetMapping("/newstatus/gdislike/{nid}")
     public Integer getdislike(@PathVariable Integer nid) {
-        Integer like = newstatusMapper.selectCount(new QueryWrapper<Newstatus>().eq("new_id", nid));
-        return like;
+        return newstatusService.getDislike(nid);
     }
 
     @ApiOperation("增加指定nid新闻的点赞数量，需传入新闻ID")
     @PostMapping("/newstatus/like")
     public Newstatus postlike(Newstatus newstatus)
     {
-        newstatus.setNewLike(newstatus.getNewLike() + 1);
-        newstatusMapper.update(newstatus, new QueryWrapper<Newstatus>().eq("new_id", newstatus.getNewId()));
-        return newstatus;
+        return newstatusService.postLike(newstatus);
     }
 
     @ApiOperation("增加指定nid新闻的点踩数量，需传入新闻ID")
     @PostMapping("/newstatus/dislike")
     public Newstatus postdislike(Newstatus newstatus) {
-        newstatus.setNewDislike(newstatus.getNewDislike() + 1);
-        newstatusMapper.update(newstatus, new QueryWrapper<Newstatus>().eq("new_id", newstatus.getNewId()));
-        return newstatus;
+        return newstatusService.postDislike(newstatus);
     }
 
     @ApiOperation("增加指定nid新闻的转发数量，需传入新闻ID")
     @PostMapping("/newstatus/forward")
     public Newstatus postforward(Newstatus newstatus) {
-        newstatus.setNewForward(newstatus.getNewForward() + 1);
-        newstatusMapper.update(newstatus, new QueryWrapper<Newstatus>().eq("new_id", newstatus.getNewId()));
-        return newstatus;
+        return newstatusService.postForward(newstatus);
     }
 }
+

--- a/back/src/main/java/com/haust/back/controller/UserController.java
+++ b/back/src/main/java/com/haust/back/controller/UserController.java
@@ -1,10 +1,8 @@
 package com.haust.back.controller;
 
-import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
-import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.haust.back.entity.User;
-import com.haust.back.mapper.UserMapper;
+import com.haust.back.service.UserService;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -12,53 +10,42 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class UserController {
     @Autowired
-    private UserMapper userMapper;
+    private UserService userService;
     @ApiOperation("登录接口，需传入用户账号和密码")
     @PostMapping("/user/login")
     public User login(@RequestBody User user) {
-        return userMapper
-            .selectOne(new QueryWrapper<User>()
-                    .eq("user_name", user.getUserName())
-                    .eq("user_pwd", user.getUserPwd()));
+        return userService.login(user);
     }
 
     @ApiOperation("对所有的用户信息进行分页查询，默认每次查询5条数据")
     @GetMapping("/user/{id}/{size}")
-    public IPage getUserPage(@PathVariable int id, @PathVariable int size) {
-        Page<User> page = new Page<>(id, size);
-        IPage iPage = userMapper.selectPage(page, null);
-        return iPage;
+    public IPage<User> getUserPage(@PathVariable int id, @PathVariable int size) {
+        return userService.getUserPage(id,size);
     }
 
     @ApiOperation("查询指定用户的详细内容，需传入用户id")
     @GetMapping("/user/{id}")
     public User getUserDetailById(@PathVariable Integer id) {
-        return userMapper.selectById(id);
+        return userService.getUserDetailById(id);
     }
 
     @ApiOperation("添加一条用户，需传入用户的详细内容")
     @PostMapping("/user/insert")
     public User insertUser(User user) {
-        User nuser = userMapper.selectOne(new QueryWrapper<User>().eq("user_name", user.getUserName()));
-        if (nuser != null)
-            return null;
-        else {
-            userMapper.insert(user);
-            return user;
-        }
+        return userService.insertUser(user);
     }
 
     @ApiOperation("更新一条用户信息，根据传入的用户id进行匹配，需传入更新用户的详细内容")
     @PutMapping("/user/update")
     public User updateUser(User user) {
-        int num = userMapper.update(user, new QueryWrapper<User>().eq("user_id", user.getUserId()));
-        return num == 1 ? user : null;
+        return userService.updateUser(user);
     }
 
     @ApiOperation("删除一条用户信息，需传入用户id进行匹配")
     @DeleteMapping("/user/{id}")
     public int deleteById(@PathVariable Integer id) {
-        return userMapper.deleteById(id);
+        return userService.deleteById(id);
     }
 
 }
+

--- a/back/src/main/java/com/haust/back/service/CommentService.java
+++ b/back/src/main/java/com/haust/back/service/CommentService.java
@@ -1,0 +1,14 @@
+package com.haust.back.service;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.haust.back.entity.Comment;
+
+public interface CommentService {
+    Comment insertComment(Comment comment);
+    IPage<Comment> getCommentById(Integer nid, int id, int size);
+    Integer getLike(Integer nid);
+    Integer getDislike(Integer nid);
+    Integer postLike(Integer nid);
+    Integer postDislike(Integer nid);
+}
+

--- a/back/src/main/java/com/haust/back/service/NewService.java
+++ b/back/src/main/java/com/haust/back/service/NewService.java
@@ -1,0 +1,15 @@
+package com.haust.back.service;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.haust.back.entity.New;
+
+public interface NewService {
+    IPage<New> getNewsPage(int id, int size);
+    IPage<New> getNewsPageByCid(int cid, int id, int size);
+    IPage<New> getNewsPageByDate(String date, int id, int size);
+    New getNewsDetailById(int id);
+    New insertNews(New news);
+    New updateNew(New news);
+    int deleteNewById(Integer id);
+}
+

--- a/back/src/main/java/com/haust/back/service/NewstatusService.java
+++ b/back/src/main/java/com/haust/back/service/NewstatusService.java
@@ -1,0 +1,13 @@
+package com.haust.back.service;
+
+import com.haust.back.entity.Newstatus;
+
+public interface NewstatusService {
+    Newstatus getStatusByNid(Integer nid);
+    Integer getLike(Integer nid);
+    Integer getDislike(Integer nid);
+    Newstatus postLike(Newstatus newstatus);
+    Newstatus postDislike(Newstatus newstatus);
+    Newstatus postForward(Newstatus newstatus);
+}
+

--- a/back/src/main/java/com/haust/back/service/UserService.java
+++ b/back/src/main/java/com/haust/back/service/UserService.java
@@ -1,0 +1,14 @@
+package com.haust.back.service;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.haust.back.entity.User;
+
+public interface UserService {
+    User login(User user);
+    IPage<User> getUserPage(int id, int size);
+    User getUserDetailById(Integer id);
+    User insertUser(User user);
+    User updateUser(User user);
+    int deleteById(Integer id);
+}
+

--- a/back/src/main/java/com/haust/back/service/impl/CommentServiceImpl.java
+++ b/back/src/main/java/com/haust/back/service/impl/CommentServiceImpl.java
@@ -1,0 +1,55 @@
+package com.haust.back.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.haust.back.entity.Comment;
+import com.haust.back.mapper.CommentMapper;
+import com.haust.back.service.CommentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+@Service
+public class CommentServiceImpl implements CommentService {
+    @Autowired
+    private CommentMapper commentMapper;
+
+    @Override
+    public Comment insertComment(Comment comment) {
+        Date date = new Date();
+        Timestamp t = new Timestamp(date.getTime());
+        comment.setCDate(t);
+        commentMapper.insert(comment);
+        return comment;
+    }
+
+    @Override
+    public IPage<Comment> getCommentById(Integer nid, int id, int size) {
+        Page<Comment> page = new Page<>(id, size);
+        return commentMapper.selectPage(page, new QueryWrapper<Comment>().eq("new_id", nid));
+    }
+
+    @Override
+    public Integer getLike(Integer nid) {
+        return commentMapper.selectCount(new QueryWrapper<Comment>().eq("new_id", nid));
+    }
+
+    @Override
+    public Integer getDislike(Integer nid) {
+        return commentMapper.selectCount(new QueryWrapper<Comment>().eq("new_id", nid));
+    }
+
+    @Override
+    public Integer postLike(Integer nid) {
+        return commentMapper.selectCount(new QueryWrapper<Comment>().eq("new_id", nid));
+    }
+
+    @Override
+    public Integer postDislike(Integer nid) {
+        return commentMapper.selectCount(new QueryWrapper<Comment>().eq("new_id", nid));
+    }
+}
+

--- a/back/src/main/java/com/haust/back/service/impl/NewServiceImpl.java
+++ b/back/src/main/java/com/haust/back/service/impl/NewServiceImpl.java
@@ -1,0 +1,57 @@
+package com.haust.back.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.haust.back.entity.New;
+import com.haust.back.mapper.NewMapper;
+import com.haust.back.service.NewService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NewServiceImpl implements NewService {
+    @Autowired
+    private NewMapper newMapper;
+
+    @Override
+    public IPage<New> getNewsPage(int id, int size) {
+        Page<New> page = new Page<>(id, size);
+        return newMapper.selectPage(page, null);
+    }
+
+    @Override
+    public IPage<New> getNewsPageByCid(int cid, int id, int size) {
+        Page<New> page = new Page<>(id, size);
+        return newMapper.selectPage(page, new QueryWrapper<New>().eq("new_cid", cid));
+    }
+
+    @Override
+    public IPage<New> getNewsPageByDate(String date, int id, int size) {
+        Page<New> page = new Page<>(id, size);
+        return newMapper.selectPage(page, new QueryWrapper<New>().eq("new_date", date));
+    }
+
+    @Override
+    public New getNewsDetailById(int id) {
+        return newMapper.selectById(id);
+    }
+
+    @Override
+    public New insertNews(New news) {
+        newMapper.insert(news);
+        return news;
+    }
+
+    @Override
+    public New updateNew(New news) {
+        int num = newMapper.update(news, new QueryWrapper<New>().eq("new_id", news.getNewId()));
+        return num == 1 ? news : null;
+    }
+
+    @Override
+    public int deleteNewById(Integer id) {
+        return newMapper.deleteById(id);
+    }
+}
+

--- a/back/src/main/java/com/haust/back/service/impl/NewstatusServiceImpl.java
+++ b/back/src/main/java/com/haust/back/service/impl/NewstatusServiceImpl.java
@@ -1,0 +1,51 @@
+package com.haust.back.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.haust.back.entity.Newstatus;
+import com.haust.back.mapper.NewstatusMapper;
+import com.haust.back.service.NewstatusService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NewstatusServiceImpl implements NewstatusService {
+    @Autowired
+    private NewstatusMapper newstatusMapper;
+
+    @Override
+    public Newstatus getStatusByNid(Integer nid) {
+        return newstatusMapper.selectOne(new QueryWrapper<Newstatus>().eq("new_id", nid));
+    }
+
+    @Override
+    public Integer getLike(Integer nid) {
+        return newstatusMapper.selectCount(new QueryWrapper<Newstatus>().eq("new_id", nid));
+    }
+
+    @Override
+    public Integer getDislike(Integer nid) {
+        return newstatusMapper.selectCount(new QueryWrapper<Newstatus>().eq("new_id", nid));
+    }
+
+    @Override
+    public Newstatus postLike(Newstatus newstatus) {
+        newstatus.setNewLike(newstatus.getNewLike() + 1);
+        newstatusMapper.update(newstatus, new QueryWrapper<Newstatus>().eq("new_id", newstatus.getNewId()));
+        return newstatus;
+    }
+
+    @Override
+    public Newstatus postDislike(Newstatus newstatus) {
+        newstatus.setNewDislike(newstatus.getNewDislike() + 1);
+        newstatusMapper.update(newstatus, new QueryWrapper<Newstatus>().eq("new_id", newstatus.getNewId()));
+        return newstatus;
+    }
+
+    @Override
+    public Newstatus postForward(Newstatus newstatus) {
+        newstatus.setNewForward(newstatus.getNewForward() + 1);
+        newstatusMapper.update(newstatus, new QueryWrapper<Newstatus>().eq("new_id", newstatus.getNewId()));
+        return newstatus;
+    }
+}
+

--- a/back/src/main/java/com/haust/back/service/impl/UserServiceImpl.java
+++ b/back/src/main/java/com/haust/back/service/impl/UserServiceImpl.java
@@ -1,0 +1,58 @@
+package com.haust.back.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.haust.back.entity.User;
+import com.haust.back.mapper.UserMapper;
+import com.haust.back.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserServiceImpl implements UserService {
+    @Autowired
+    private UserMapper userMapper;
+
+    @Override
+    public User login(User user) {
+        return userMapper
+            .selectOne(new QueryWrapper<User>()
+                    .eq("user_name", user.getUserName())
+                    .eq("user_pwd", user.getUserPwd()));
+    }
+
+    @Override
+    public IPage<User> getUserPage(int id, int size) {
+        Page<User> page = new Page<>(id, size);
+        return userMapper.selectPage(page, null);
+    }
+
+    @Override
+    public User getUserDetailById(Integer id) {
+        return userMapper.selectById(id);
+    }
+
+    @Override
+    public User insertUser(User user) {
+        User nuser = userMapper.selectOne(new QueryWrapper<User>().eq("user_name", user.getUserName()));
+        if (nuser != null)
+            return null;
+        else {
+            userMapper.insert(user);
+            return user;
+        }
+    }
+
+    @Override
+    public User updateUser(User user) {
+        int num = userMapper.update(user, new QueryWrapper<User>().eq("user_id", user.getUserId()));
+        return num == 1 ? user : null;
+    }
+
+    @Override
+    public int deleteById(Integer id) {
+        return userMapper.deleteById(id);
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce service interfaces and implementations for news, users, comments and newstatus
- refactor controllers to use services instead of mappers

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:2.7.6)*

------
https://chatgpt.com/codex/tasks/task_b_68986c148788832ba5a018175098392c